### PR TITLE
map(), format(), filter(), lowercase(), tupilize()

### DIFF
--- a/CSE687_Group4/map.cpp
+++ b/CSE687_Group4/map.cpp
@@ -40,11 +40,11 @@ Map::Map()
 
 }
 
-stringstream Map::map(string text) 
+string Map::map(string text) 
 // string text : a full line of text to parse through
 {
   stringstream ss_in;
-  stringstream ss_out;
+  string output = "";
   string word = "";
 
   ss_in << text;
@@ -52,11 +52,11 @@ stringstream Map::map(string text)
     word = format(word);
     if (word != "") {
       word = tuplize(word);
-      ss_out << word;
+      output.append(word);
     }
   }
 
-  return ss_out;
+  return output;
 }
 
 

--- a/CSE687_Group4/map.h
+++ b/CSE687_Group4/map.h
@@ -30,13 +30,12 @@ ver 1.0 : 14 April 2023
 #include <string>
 #include <sstream>
 using std::string;
-using std::stringstream;
 
 class Map {
 public:
   Map(); // Constructor
 
-  stringstream map(string); // Accepts a single line of raw data from file and tokenize into distinct words
+  string map(string); // Accepts a single line of raw data from file and tokenize into distinct words
 
   bool const GetFlag(); // Returns object's flag
   void SetFlag(bool); // Sets object's flag


### PR DESCRIPTION
Fleshes out the map class, map() will break up an input string into individual words and turns them into the (word, 1) tuples, outputting a single string with new lines delimiting each tuple.

Output of Map.map():
(a, 1)\n(word, 1)\n(is, 1)\n(a, 1) . . .
